### PR TITLE
Update DealClient.sol

### DIFF
--- a/src/basic-deal-client/DealClient.sol
+++ b/src/basic-deal-client/DealClient.sol
@@ -5,7 +5,6 @@ import {MarketAPI} from "@zondax/filecoin-solidity/contracts/v0.8/MarketAPI.sol"
 import {CommonTypes} from "@zondax/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
 import {MarketTypes} from "@zondax/filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
 import {AccountTypes} from "@zondax/filecoin-solidity/contracts/v0.8/types/AccountTypes.sol";
-import {CommonTypes} from "@zondax/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
 import {AccountCBOR} from "@zondax/filecoin-solidity/contracts/v0.8/cbor/AccountCbor.sol";
 import {MarketCBOR} from "@zondax/filecoin-solidity/contracts/v0.8/cbor/MarketCbor.sol";
 import {BytesCBOR} from "@zondax/filecoin-solidity/contracts/v0.8/cbor/BytesCbor.sol";


### PR DESCRIPTION
@ZakAyesh , i think we dont need to import this twice , so i just removed it . import {CommonTypes} from "@zondax/filecoin-solidity/contracts/v0.8/types/CommonTypes.sol"; 